### PR TITLE
# fix README.md some error, add PERPLEXICA_READ_TIMEOUT env config fo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Add the following to your Claude Desktop configuration file:
   "mcpServers": {
     "perplexica": {
       "command": "uv",
-      "args": ["run", "/path/to/perplexica-mcp/src/perplexica_mcp.py", "stdio"],
+      "args": ["run", "/path/to/perplexica-mcp/src/perplexica_mcp/server.py", "stdio"],
       "env": {
         "PERPLEXICA_BACKEND_URL": "http://localhost:3000/api/search"
       }
@@ -154,7 +154,7 @@ Add to your Cursor MCP configuration:
   "servers": {
     "perplexica": {
       "command": "uv",
-      "args": ["run", "/path/to/perplexica-mcp/src/perplexica_mcp.py", "stdio"],
+      "args": ["run", "/path/to/perplexica-mcp/src/perplexica_mcp/server.py", "stdio"],
       "env": {
         "PERPLEXICA_BACKEND_URL": "http://localhost:3000/api/search"
       }
@@ -172,7 +172,7 @@ For any MCP client supporting stdio transport:
 uvx perplexica-mcp stdio
 
 # Command to run the server (from source)
-uv run /path/to/perplexica-mcp/src/perplexica_mcp.py stdio
+uv run /path/to/perplexica-mcp/src/perplexica_mcp/server.py stdio
 
 # Environment variables
 PERPLEXICA_BACKEND_URL=http://localhost:3000/api/search
@@ -185,7 +185,7 @@ For HTTP/SSE transport clients:
 uvx perplexica-mcp sse  # or 'http'
 
 # Start the server (from source)
-uv run /path/to/perplexica-mcp/src/perplexica_mcp.py sse  # or 'http'
+uv run /path/to/perplexica-mcp/src/perplexica_mcp/server.py sse  # or 'http'
 
 # Connect to endpoints
 SSE: http://localhost:3001/sse

--- a/src/perplexica_mcp/server.py
+++ b/src/perplexica_mcp/server.py
@@ -15,6 +15,7 @@ load_dotenv()
 
 # Get the backend URL from environment variable or use default
 PERPLEXICA_BACKEND_URL = os.getenv('PERPLEXICA_BACKEND_URL', 'http://localhost:3000/api/search')
+PERPLEXICA_READ_TIMEOUT = int(os.getenv('PERPLEXICA_READ_TIMEOUT', 30))
 
 # Create FastMCP server with settings for all transports
 settings = Settings(
@@ -86,7 +87,7 @@ async def perplexica_search(
             response = await client.post(
                 PERPLEXICA_BACKEND_URL,
                 json=payload,
-                timeout=30.0
+                timeout=PERPLEXICA_READ_TIMEOUT
             )
             response.raise_for_status()
             return response.json()


### PR DESCRIPTION
I add env config for the reason that perhaps it may occur some search timeout error and no valid message output and fix some error in README.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the HTTP request timeout using the PERPLEXICA_READ_TIMEOUT environment variable.

* **Documentation**
  * Updated the README to correct example commands and configuration paths for running the server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->