### PR TITLE
Add environment variables for models 

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -1,1 +1,13 @@
+# Perplexica Backend Configuration
 PERPLEXICA_BACKEND_URL=http://localhost:3000/api/search
+
+# Default Model Configuration (Optional)
+# If set, these models will be used as defaults when no model is specified in the search request
+
+# Chat Model Configuration
+PERPLEXICA_CHAT_MODEL_PROVIDER=openai
+PERPLEXICA_CHAT_MODEL_NAME=gpt-4o-mini
+
+# Embedding Model Configuration  
+PERPLEXICA_EMBEDDING_MODEL_PROVIDER=openai
+PERPLEXICA_EMBEDDING_MODEL_NAME=text-embedding-3-small

--- a/README.md
+++ b/README.md
@@ -88,7 +88,11 @@ Add the following to your Claude Desktop configuration file:
       "command": "uvx",
       "args": ["perplexica-mcp", "stdio"],
       "env": {
-        "PERPLEXICA_BACKEND_URL": "http://localhost:3000/api/search"
+        "PERPLEXICA_BACKEND_URL": "http://localhost:3000/api/search",
+        "PERPLEXICA_CHAT_MODEL_PROVIDER": "openai",
+        "PERPLEXICA_CHAT_MODEL_NAME": "gpt-4o-mini",
+        "PERPLEXICA_EMBEDDING_MODEL_PROVIDER": "openai",
+        "PERPLEXICA_EMBEDDING_MODEL_NAME": "text-embedding-3-small"
       }
     }
   }
@@ -103,7 +107,11 @@ Add the following to your Claude Desktop configuration file:
       "command": "uv",
       "args": ["run", "/path/to/perplexica-mcp/src/perplexica_mcp.py", "stdio"],
       "env": {
-        "PERPLEXICA_BACKEND_URL": "http://localhost:3000/api/search"
+        "PERPLEXICA_BACKEND_URL": "http://localhost:3000/api/search",
+        "PERPLEXICA_CHAT_MODEL_PROVIDER": "openai",
+        "PERPLEXICA_CHAT_MODEL_NAME": "gpt-4o-mini",
+        "PERPLEXICA_EMBEDDING_MODEL_PROVIDER": "openai",
+        "PERPLEXICA_EMBEDDING_MODEL_NAME": "text-embedding-3-small"
       }
     }
   }
@@ -141,7 +149,11 @@ Add to your Cursor MCP configuration:
       "command": "uvx",
       "args": ["perplexica-mcp", "stdio"],
       "env": {
-        "PERPLEXICA_BACKEND_URL": "http://localhost:3000/api/search"
+        "PERPLEXICA_BACKEND_URL": "http://localhost:3000/api/search",
+        "PERPLEXICA_CHAT_MODEL_PROVIDER": "openai",
+        "PERPLEXICA_CHAT_MODEL_NAME": "gpt-4o-mini",
+        "PERPLEXICA_EMBEDDING_MODEL_PROVIDER": "openai",
+        "PERPLEXICA_EMBEDDING_MODEL_NAME": "text-embedding-3-small"
       }
     }
   }
@@ -156,7 +168,11 @@ Add to your Cursor MCP configuration:
       "command": "uv",
       "args": ["run", "/path/to/perplexica-mcp/src/perplexica_mcp.py", "stdio"],
       "env": {
-        "PERPLEXICA_BACKEND_URL": "http://localhost:3000/api/search"
+        "PERPLEXICA_BACKEND_URL": "http://localhost:3000/api/search",
+        "PERPLEXICA_CHAT_MODEL_PROVIDER": "openai",
+        "PERPLEXICA_CHAT_MODEL_NAME": "gpt-4o-mini",
+        "PERPLEXICA_EMBEDDING_MODEL_PROVIDER": "openai",
+        "PERPLEXICA_EMBEDDING_MODEL_NAME": "text-embedding-3-small"
       }
     }
   }
@@ -176,6 +192,10 @@ uv run /path/to/perplexica-mcp/src/perplexica_mcp.py stdio
 
 # Environment variables
 PERPLEXICA_BACKEND_URL=http://localhost:3000/api/search
+PERPLEXICA_CHAT_MODEL_PROVIDER=openai
+PERPLEXICA_CHAT_MODEL_NAME=gpt-4o-mini
+PERPLEXICA_EMBEDDING_MODEL_PROVIDER=openai
+PERPLEXICA_EMBEDDING_MODEL_NAME=text-embedding-3-small
 ```
 
 For HTTP/SSE transport clients:
@@ -214,8 +234,32 @@ HTTP: http://localhost:3002/mcp/
 Create a `.env` file in the project root with your Perplexica configuration:
 
 ```env
+# Perplexica Backend Configuration
 PERPLEXICA_BACKEND_URL=http://localhost:3000/api/search
+
+# Default Model Configuration (Optional)
+# If set, these models will be used as defaults when no model is specified in the search request
+
+# Chat Model Configuration
+PERPLEXICA_CHAT_MODEL_PROVIDER=openai
+PERPLEXICA_CHAT_MODEL_NAME=gpt-4o-mini
+
+# Embedding Model Configuration  
+PERPLEXICA_EMBEDDING_MODEL_PROVIDER=openai
+PERPLEXICA_EMBEDDING_MODEL_NAME=text-embedding-3-small
 ```
+
+### Environment Variables
+
+| Variable | Description | Default | Example |
+|----------|-------------|---------|---------|
+| `PERPLEXICA_BACKEND_URL` | URL to Perplexica search API | `http://localhost:3000/api/search` | `http://localhost:3000/api/search` |
+| `PERPLEXICA_CHAT_MODEL_PROVIDER` | Default chat model provider | None | `openai`, `ollama`, `anthropic` |
+| `PERPLEXICA_CHAT_MODEL_NAME` | Default chat model name | None | `gpt-4o-mini`, `claude-3-sonnet` |
+| `PERPLEXICA_EMBEDDING_MODEL_PROVIDER` | Default embedding model provider | None | `openai`, `ollama` |
+| `PERPLEXICA_EMBEDDING_MODEL_NAME` | Default embedding model name | None | `text-embedding-3-small` |
+
+**Note**: The model environment variables are optional. If not set, you'll need to specify models in each search request. When set, they provide convenient defaults that can still be overridden per request.
 
 ## Usage
 

--- a/src/perplexica_mcp/server.py
+++ b/src/perplexica_mcp/server.py
@@ -16,6 +16,21 @@ load_dotenv()
 # Get the backend URL from environment variable or use default
 PERPLEXICA_BACKEND_URL = os.getenv('PERPLEXICA_BACKEND_URL', 'http://localhost:3000/api/search')
 
+# Default model configurations from environment variables
+DEFAULT_CHAT_MODEL = None
+if os.getenv("PERPLEXICA_CHAT_MODEL_PROVIDER") and os.getenv("PERPLEXICA_CHAT_MODEL_NAME"):
+    DEFAULT_CHAT_MODEL = {
+        "provider": os.getenv("PERPLEXICA_CHAT_MODEL_PROVIDER"),
+        "name": os.getenv("PERPLEXICA_CHAT_MODEL_NAME"),
+    }
+
+DEFAULT_EMBEDDING_MODEL = None
+if os.getenv("PERPLEXICA_EMBEDDING_MODEL_PROVIDER") and os.getenv("PERPLEXICA_EMBEDDING_MODEL_NAME"):
+    DEFAULT_EMBEDDING_MODEL = {
+        "provider": os.getenv("PERPLEXICA_EMBEDDING_MODEL_PROVIDER"),
+        "name": os.getenv("PERPLEXICA_EMBEDDING_MODEL_NAME"),
+    }
+
 # Create FastMCP server with settings for all transports
 settings = Settings(
     host="0.0.0.0",
@@ -99,8 +114,8 @@ async def perplexica_search(
 async def search(
     query: Annotated[str, Field(description="Search query")],
     focus_mode: Annotated[str, Field(description="Focus mode: webSearch, academicSearch, writingAssistant, wolframAlphaSearch, youtubeSearch, redditSearch")],
-    chat_model: Annotated[dict, Field(description="Chat model configuration")] = None,
-    embedding_model: Annotated[dict, Field(description="Embedding model configuration")] = None,
+    chat_model: Annotated[dict, Field(description="Chat model configuration")] = DEFAULT_CHAT_MODEL,
+    embedding_model: Annotated[dict, Field(description="Embedding model configuration")] = DEFAULT_EMBEDDING_MODEL,
     optimization_mode: Annotated[str, Field(description="Optimization mode: speed or balanced")] = None,
     history: Annotated[list, Field(description="Conversation history")] = None,
     system_instructions: Annotated[str, Field(description="Custom system instructions")] = None,


### PR DESCRIPTION
Hell @thetom42 
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
Thank you for creating this project! Really helpful for my MCP clients. I was running into an issue where Perplexica would fail with the error: 
`Error [ResponseError]: this model does not support embeddings`

This happened because the MCP server wasn't specifying models. I think Perplexica was falling back to defaults that didn't support embeddings. 
This PR adds optional environment variable support for default model configuration:

     • PERPLEXICA_CHAT_MODEL_PROVIDER / PERPLEXICA_CHAT_MODEL_NAME                                                                                                                                                                                                                            
     • PERPLEXICA_EMBEDDING_MODEL_PROVIDER / PERPLEXICA_EMBEDDING_MODEL_NAME 

When set, these can still be overridden per request. I've also updated the documentation with examples using OpenAI models and enhanced the .sample.env file.

The changes are minimal and backward-compatible.                                                                                                                                                  
If you need further changes, please let me know!
Ricardo
   