### PR TITLE
Solved Dockerfile run problem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apk add --no-cache \
 
 # Copy requirements first for better caching
 COPY pyproject.toml ./
+COPY README.md ./
 
 # Install Python dependencies using uv
 RUN pip install --no-cache-dir -e .
@@ -29,4 +30,4 @@ EXPOSE 3001 3002
 ENV PERPLEXICA_BACKEND_URL=http://localhost:3000/api/search
 
 # Default command (can be overridden)
-CMD ["python", "src/perplexica_mcp.py", "http", "0.0.0.0", "3001"]
+CMD ["python", "src/perplexica_mcp/server.py", "http", "0.0.0.0", "3001"]

--- a/src/perplexica_mcp/server.py
+++ b/src/perplexica_mcp/server.py
@@ -17,15 +17,13 @@ load_dotenv()
 PERPLEXICA_BACKEND_URL = os.getenv('PERPLEXICA_BACKEND_URL', 'http://localhost:3000/api/search')
 
 # Create FastMCP server with settings for all transports
-settings = Settings(
+mcp = FastMCP("Perplexica", dependencies=["httpx", "mcp", "python-dotenv", "uvicorn"],
     host="0.0.0.0",
     port=3001,
     sse_path="/sse",
     message_path="/messages/",
     streamable_http_path="/mcp"
 )
-
-mcp = FastMCP("Perplexica", dependencies=["httpx", "mcp", "python-dotenv", "uvicorn"], settings=settings)
 
 async def perplexica_search(
     query, focus_mode,


### PR DESCRIPTION
resolves #14 and #15 .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - README is now bundled in the Docker image for in-container reference.
- Chores
  - Updated default container command to start the server via perplexica_mcp/server.py.
- Refactor
  - Simplified server initialization by configuring FastMCP directly; no user-facing changes expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->