### PR TITLE
fix HTTP 421  Misdirected Request

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,10 +29,9 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-  "mcp[cli]",
+  "fastmcp",
   "httpx",
   "python-dotenv",
-  "uvicorn",
 ]
 
 [project.urls]

--- a/src/perplexica_mcp/server.py
+++ b/src/perplexica_mcp/server.py
@@ -5,9 +5,8 @@ import os
 from typing import Annotated, Optional
 
 import httpx
-import uvicorn
 from dotenv import load_dotenv
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 from pydantic import Field
 
 # Load environment variables from .env file
@@ -39,7 +38,7 @@ if os.getenv("PERPLEXICA_EMBEDDING_MODEL_PROVIDER") and os.getenv(
     }
 
 # Create FastMCP server with default settings
-mcp = FastMCP("Perplexica", dependencies=["httpx", "mcp", "python-dotenv", "uvicorn"])
+mcp = FastMCP("Perplexica")
 
 
 async def perplexica_search(
@@ -187,22 +186,19 @@ def main():
     args = parser.parse_args()
 
     if args.transport == "stdio":
-        # Use FastMCP's stdio transport
-        mcp.run()
+        mcp.run(transport="stdio")
     elif args.transport == "sse":
-        # Use FastMCP's SSE transport
         print(
             f"Starting Perplexica MCP server with SSE transport on {args.host}:{args.port}"
         )
         print(f"SSE endpoint: http://{args.host}:{args.port}/sse")
-        uvicorn.run(mcp.sse_app(), host=args.host, port=args.port)
+        mcp.run(transport="sse", host=args.host, port=args.port)
     elif args.transport == "http":
-        # Use FastMCP's Streamable HTTP transport
         print(
             f"Starting Perplexica MCP server with Streamable HTTP transport on {args.host}:{args.port}"
         )
         print(f"HTTP endpoint: http://{args.host}:{args.port}/mcp")
-        uvicorn.run(mcp.streamable_http_app(), host=args.host, port=args.port)
+        mcp.run(transport="http", host=args.host, port=args.port, path="/mcp")
 
 
 if __name__ == "__main__":

--- a/src/test_clientside.py
+++ b/src/test_clientside.py
@@ -1,0 +1,14 @@
+from fastmcp import Client
+import asyncio
+
+SERVER_IP = "..."  # Replace with the server side IP address. Should test both localhost and actual IP.
+SERVER_PORT = 12345  # Replace with the port number set by test_serverside.sh
+
+async def main():
+    async with Client(f"http://{SERVER_IP}:{SERVER_PORT}/mcp") as client:
+        tools = await client.list_tools()
+        print(tools)
+        result = await client.call_tool('search', {'query': 'How much is iPhone 17 pro', 'focus_mode': 'webSearch', 'system_instructions': 'Your response should be less than 100 words.'})
+        print(result)
+    
+asyncio.run(main())

--- a/src/test_serverside.sh
+++ b/src/test_serverside.sh
@@ -1,0 +1,11 @@
+# Perplexica Backend Configuration
+export PERPLEXICA_BACKEND_URL="http://[ip]:[port]/api/search" # Replace with the actual backend URL
+
+# Default Model Configuration
+export PERPLEXICA_CHAT_MODEL_PROVIDER="openai"
+export PERPLEXICA_CHAT_MODEL_NAME="gpt-3.5-turbo"
+
+export PERPLEXICA_EMBEDDING_MODEL_PROVIDER="openai"
+export PERPLEXICA_EMBEDDING_MODEL_NAME="text-embedding-3-small"
+
+uv run src/perplexica_mcp/server.py http 0.0.0.0 12345


### PR DESCRIPTION
In previous code, host parameter in src/perplexica_mcp/server.py is not used in FastMCP. This may cause HTTP 421  Misdirected Request if perplexica_mcp is called by an ip address rather than "localhost". 

This commit set host parameter in FastMCP's run method to make sure 0.0.0.0 will be used if set. To achieved this, explicit usage of uvicorn is abandoned and previous fastmcp V1 in mcp lib is replaced by newer standalone fastmcp V2 lib.

Test scripts for both serverside and clientside is provided.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Server now supports multiple transport protocols (stdio, SSE, HTTP) for flexible deployment across different environments and integration scenarios.

* **Chores**
  * Optimized and updated core runtime dependencies to streamline server initialization and reduce resource requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->